### PR TITLE
Revert "Add NickServ CERT IDENTIFY support"

### DIFF
--- a/help/default/nickserv/cert
+++ b/help/default/nickserv/cert
@@ -2,15 +2,11 @@ Help for CERT:
 
 CERT maintains a list of CertFP fingerprints that will allow
 &nick& to recognize you and authenticate you automatically.
-It also allows you to re-identify yourself using your current
-CertFP fingerprint.
 
 You cannot add the same fingerprint to multiple accounts.
 
 Syntax: CERT LIST
 Syntax: CERT ADD [fingerprint]
-Syntax: CERT ID
-Syntax: CERT IDENTIFY
 Syntax: CERT DEL <fingerprint>
 #if priv user:auspex
 
@@ -21,8 +17,6 @@ Syntax: CERT LIST <nick>
 #endif
 
 Examples:
+    /msg &nick& CERT LIST
     /msg &nick& CERT ADD f3a1aad46ca88e180c25c9c7021a4b3a
     /msg &nick& CERT DEL f3a1aad46ca88e180c25c9c7021a4b3a
-    /msg &nick& CERT ID
-    /msg &nick& CERT IDENTIFY
-    /msg &nick& CERT LIST

--- a/modules/nickserv/cert.c
+++ b/modules/nickserv/cert.c
@@ -36,13 +36,11 @@ static void ns_cmd_cert(sourceinfo_t *si, int parc, char *parv[])
 	mowgli_node_t *n;
 	char *mcfp;
 	mycertfp_t *cert;
-	user_t *cu;
-	service_t *ns;
 
 	if (parc < 1)
 	{
 		command_fail(si, fault_needmoreparams, STR_INSUFFICIENT_PARAMS, "CERT");
-		command_fail(si, fault_needmoreparams, _("Syntax: CERT ADD|DEL|IDENTIFY|LIST [fingerprint]"));
+		command_fail(si, fault_needmoreparams, _("Syntax: CERT ADD|DEL|LIST [fingerprint]"));
 		return;
 	}
 
@@ -156,45 +154,6 @@ static void ns_cmd_cert(sourceinfo_t *si, int parc, char *parv[])
 		command_success_nodata(si, _("Deleted fingerprint \2%s\2 from your fingerprint list."), parv[1]);
 		logcommand(si, CMDLOG_SET, "CERT:DEL: \2%s\2", parv[1]);
 		mycertfp_delete(cert);
-	}
-	else if (!strcasecmp(parv[0], "IDENTIFY") || !strcasecmp(parv[0], "ID"))
-	{
-		cu = si->su;
-		if (cu->certfp == NULL) // No fingerprint
-		{
-			command_fail(si, fault_nochange, _("You don't have a fingerprint."));
-		}
-		
-		cert = mycertfp_find(cu->certfp);
-		if (cert == NULL) // Fingerprint not in DB
-		{
-			command_fail(si, fault_nochange, _("Your current fingerprint doesn't match any accounts."));
-			return;
-		}
-		
-		ns = service_find("nickserv");
-		if (ns == NULL)
-		{
-			return;
-		}
-		
-		mu = cert->mu;
-		
-		if (cu->myuser != NULL) // Already logged in.
-		{
-			command_fail(si, fault_nochange, _("You are already logged in as \2%s\2."), entity(cu->myuser)->name);
-			return;
-		}
-		
-		if (MOWGLI_LIST_LENGTH(&mu->logins) >= me.maxlogins)
-		{
-			command_fail(si, fault_toomany, _("There are already \2%zu\2 sessions logged in to \2%s\2 (maximum allowed: %u)."), MOWGLI_LIST_LENGTH(&mu->logins), entity(mu)->name, me.maxlogins);
-			return;
-		}
-		
-		myuser_login(ns, cu, mu, true);
-		logcommand_user(ns, cu, CMDLOG_LOGIN, "LOGIN via CERT IDENTIFY (%s)", cu->certfp);
-		notice(ns->nick, cu->nick, nicksvs.no_nick_ownership ? _("You are now logged in as \2%s\2.") : _("You are now identified for \2%s\2."), entity(mu)->name);
 	}
 	else
 	{


### PR DESCRIPTION
Reverts XthemeOrg/Xtheme#10 - Removes NickServ CERT IDENTIFY since better solutions are already on the horizon.