### PR TITLE
ChanServ MODERATE Fix HELP paths

### DIFF
--- a/modules/chanserv/moderate.c
+++ b/modules/chanserv/moderate.c
@@ -35,11 +35,11 @@ static void cs_cmd_waiting(sourceinfo_t *si, int parc, char *parv[]);
 static void can_register(hook_channel_register_check_t *req);
 
 static command_t cs_activate = { "ACTIVATE", N_("Activates a pending registration"), PRIV_CHAN_ADMIN,
-				 2, cs_cmd_activate, { .path = "chanserv/activate" } };
+				 2, cs_cmd_activate, { .path = "cservice/activate" } };
 static command_t cs_reject   = { "REJECT", N_("Rejects a pending registration"), PRIV_CHAN_ADMIN,
-				 2, cs_cmd_reject, { .path = "chanserv/reject" } };
+				 2, cs_cmd_reject, { .path = "cservice/reject" } };
 static command_t cs_waiting  = { "WAITING", N_("View pending registrations"), PRIV_CHAN_ADMIN,
-				 1, cs_cmd_waiting, { .path = "chanserv/waiting" } };
+				 1, cs_cmd_waiting, { .path = "cservice/waiting" } };
 
 typedef struct {
 	char *name;


### PR DESCRIPTION
Actually fix the problem with ChanServ MODERATE's HELP commands not being available. 