### PR TITLE
Update help for hostserv/drop

### DIFF
--- a/help/default/hostserv/drop
+++ b/help/default/hostserv/drop
@@ -1,8 +1,9 @@
 Help for DROP:
 
-Drops (unsets) the vHost currently assigned to the nick in use.
+Drops (unsets) the vHost assigned to the nick in use.
 When you use this command, any user who performs a /whois
-on your nick will see your real IP address.
+on your nick will see the original host given to you by the IRCd,
+which may show your real IP address.
 
 Syntax: DROP
 


### PR DESCRIPTION
Correction: only in some IRCds will removing a vHost show the user's real IP/host; this is known (atheme/atheme#313) but still has yet to be fixed.
Also, shorten the first line of the description ("currently assigned" is a bit wordy/repetitive)